### PR TITLE
Add simple language toggle

### DIFF
--- a/src/app/contexts/LanguageContext.tsx
+++ b/src/app/contexts/LanguageContext.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import React, { createContext, useState, useEffect, ReactNode } from 'react'
+
+export type Language = 'es' | 'en' | 'qu'
+
+interface LanguageContextProps {
+  lang: Language
+  setLang: (lang: Language) => void
+  t: (key: string) => string
+}
+
+const defaultContext: LanguageContextProps = {
+  lang: 'es',
+  setLang: () => {},
+  t: (key: string) => key,
+}
+
+export const LanguageContext = createContext<LanguageContextProps>(defaultContext)
+
+const translations: Record<Language, Record<string, string>> = {
+  es: {
+    home: 'Inicio',
+    recipes: 'Recetas',
+    plants: 'Plantas',
+    all: 'Todas',
+    about: 'Nosotros',
+    recognizePlant: 'Reconocer planta',
+    addForum: 'Agregar foro',
+    login: 'Iniciar sesión',
+    register: 'Registrarse',
+    welcomeUser: 'Bienvenido,',
+    logout: 'Cerrar Sesión',
+    language: 'Idioma',
+    welcomeEcoExplora: 'Bienvenido a EcoExplora',
+    whatIsEcoExplora: '¿Qué es EcoExplora?',
+  },
+  en: {
+    home: 'Home',
+    recipes: 'Recipes',
+    plants: 'Plants',
+    all: 'All',
+    about: 'About us',
+    recognizePlant: 'Identify plant',
+    addForum: 'Add forum',
+    login: 'Login',
+    register: 'Register',
+    welcomeUser: 'Welcome,',
+    logout: 'Logout',
+    language: 'Language',
+    welcomeEcoExplora: 'Welcome to EcoExplora',
+    whatIsEcoExplora: 'What is EcoExplora?',
+  },
+  qu: {
+    home: 'Kallari',
+    recipes: 'Aycha mikuna',
+    plants: 'Yuyaykuna',
+    all: 'Tuku',
+    about: 'Ñukanchik',
+    recognizePlant: 'Yuyay rikuchiy',
+    addForum: 'Yupay forum',
+    login: 'Yaykuy',
+    register: 'Tantanakuy',
+    welcomeUser: 'Alli shamushka,',
+    logout: 'Llakichiy',
+    language: 'Shimi',
+    welcomeEcoExplora: 'Alli shamuy EcoExplora-man',
+    whatIsEcoExplora: 'Imatach EcoExplora?',
+  },
+}
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLangState] = useState<Language>('es')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lang') as Language | null
+    if (stored) setLangState(stored)
+  }, [])
+
+  const setLang = (newLang: Language) => {
+    setLangState(newLang)
+    localStorage.setItem('lang', newLang)
+  }
+
+  const t = (key: string): string => {
+    const value = translations[lang][key]
+    return value || key
+  }
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import Nav from './ui/Nav'
+import { LanguageProvider } from './contexts/LanguageContext'
 
 const geistSans = Geist({
     variable: '--font-geist-sans',
@@ -26,8 +27,10 @@ export default function RootLayout({
     return (
         <html lang='en'>
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-                <Nav />
-                {children}
+                <LanguageProvider>
+                    <Nav />
+                    {children}
+                </LanguageProvider>
             </body>
         </html>
     )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,11 @@
-import Buscador from './ui/Buscador'
+'use client'
 
-export default async function Page() {
+import Buscador from './ui/Buscador'
+import { useContext } from 'react'
+import { LanguageContext } from './contexts/LanguageContext'
+
+export default function Page() {
+    const { t } = useContext(LanguageContext)
     // console.log('API URL:', process.env.NEXT_PUBLIC_API_URL)
     // let cargado = false
     // const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/planta`, {
@@ -19,12 +24,12 @@ export default async function Page() {
         <>
             <section className='welcome '>
                 <h1 className='text-shadow text-4xl font-bold text-green-800 px-4 py-6 rounded-xl text-center'>
-                    Bienvenido a EcoExplora
+                    {t('welcomeEcoExplora')}
                 </h1>
             </section>
             <section className='intro-ecoexplora px-6 py-8 bg-green-50 text-center max'>
                 <div className='max-w-3xl mx-auto'>
-                    <h2 className='text-2xl text-green-700 mb-4'>¿Qué es EcoExplora?</h2>
+                    <h2 className='text-2xl text-green-700 mb-4'>{t('whatIsEcoExplora')}</h2>
                     <p className='text-lg leading-relaxed text-gray-700'>
                         <strong>EcoExplora</strong> es un repositorio digital de plantas
                         clasificadas en categorías como medicinales, ornamentales, frutales y

--- a/src/app/ui/LanguageToggle.tsx
+++ b/src/app/ui/LanguageToggle.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useContext } from 'react'
+import { LanguageContext, Language } from '../contexts/LanguageContext'
+
+export default function LanguageToggle() {
+  const { lang, setLang, t } = useContext(LanguageContext)
+
+  const changeLanguage = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setLang(e.target.value as Language)
+  }
+
+  return (
+    <select
+      className='bg-white text-green-700 rounded px-2 py-1 text-sm'
+      value={lang}
+      onChange={changeLanguage}
+      aria-label={t('language')}
+    >
+      <option value='es'>ES</option>
+      <option value='en'>EN</option>
+      <option value='qu'>KI</option>
+    </select>
+  )
+}

--- a/src/app/ui/Nav.tsx
+++ b/src/app/ui/Nav.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useContext } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { Leaf, UserCircle, LogOut } from 'lucide-react'
 import { jwtDecode } from 'jwt-decode'
 import LoginModal from '../components/modals/LoginModal'
 import RegisterModal from '../components/modals/RegisterModal'
+import LanguageToggle from './LanguageToggle'
+import { LanguageContext } from '../contexts/LanguageContext'
 
 // --- Interfaces para tipado ---
 interface User {
@@ -22,13 +24,14 @@ interface DecodedToken extends User {
 
 // --- Componentes y Constantes ---
 const navItems = [
-    { label: 'Inicio', href: '/' },
-    { label: 'Recetas', href: '/recetas' },
+    { key: 'home', href: '/' },
+    { key: 'recipes', href: '/recetas' },
 ]
 
 const categorias = ['Medicinales', 'Ornamentales', 'Frutales', 'Aromáticas']
 
 export default function Navbar() {
+    const { t } = useContext(LanguageContext)
     const [mobileOpen, setMobileOpen] = useState(false)
     const [plantOpen, setPlantOpen] = useState(false)
     
@@ -135,31 +138,34 @@ export default function Navbar() {
                     {/* Menú de escritorio (sin cambios) */}
                     <ul className='hidden md:flex items-center space-x-6 text-white text-lg font-medium'>
                          {/* Items de navegación, dropdown de plantas, botones, etc. (Idéntico a tu código original) */}
-                         {navItems.map(({ label, href }) => (
+                         {navItems.map(({ key, href }) => (
                             <li key={href}>
                                 <Link href={href} className={`hover:text-green-200 transition ${pathname === href ? 'underline underline-offset-4' : ''}`}>
-                                    {label}
+                                    {t(key)}
                                 </Link>
                             </li>
                         ))}
                         <li className='relative' ref={dropdownRef}>
                             <button onClick={() => setPlantOpen(open => !open)} className='flex items-center hover:text-green-200 transition focus:outline-none'>
-                                Plantas
+                                {t('plants')}
                                 <svg className={`w-4 h-4 ml-1 transition-transform ${plantOpen ? 'rotate-180' : ''}`} fill='none' stroke='currentColor' viewBox='0 0 24 24'>
                                     <path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M19 9l-7 7-7-7' />
                                 </svg>
                             </button>
                             {plantOpen && (
                                 <ul className='absolute left-0 mt-2 bg-white text-green-700 rounded shadow-lg min-w-[8rem] z-10'>
-                                    <li><Link href='/plantas' className='block px-4 py-2 hover:bg-green-100' onClick={() => setPlantOpen(false)}>Todas</Link></li>
+                                    <li><Link href='/plantas' className='block px-4 py-2 hover:bg-green-100' onClick={() => setPlantOpen(false)}>{t('all')}</Link></li>
                                     {categorias.map(cat => (<li key={cat}><Link href={`/plantas/${cat}`} className='block px-4 py-2 hover:bg-green-100' onClick={() => setPlantOpen(false)}>{cat}</Link></li>))}
                                 </ul>
                             )}
                         </li>
-                        <li><Link href="/nosotros" className={`hover:text-green-200 transition ${pathname === '/nosotros' ? 'underline underline-offset-4' : ''}`}>Nosotros</Link></li>
-                        <li><Link href='/ingresar' className='inline-flex items-center gap-2 bg-green-500 text-white font-semibold px-4 py-2 rounded-xl shadow hover:bg-green-600 transition whitespace-nowrap overflow-hidden text-ellipsis'><Leaf className='w-4 h-4' /> Reconocer planta</Link></li>
-                        {user && (<li><Link href='/crear-foro' className='inline-flex items-center gap-2 bg-white text-green-700 font-semibold px-4 py-2 rounded-xl shadow hover:bg-green-100 transition whitespace-nowrap'>Agregar foro</Link></li>)}
-                        <div className='flex items-center space-x-4 ml-6 '>{user ? (<><li><span className='flex items-center'><UserCircle className='mr-2 h-5 w-5' /> Bienvenido, {user.nombre}</span></li><li><button onClick={handleLogout} className='inline-flex items-center gap-2 bg-red-500 text-white font-semibold px-4 py-2 rounded-xl shadow hover:bg-red-600 transition'><LogOut className='w-4 h-4' /> Cerrar Sesión</button></li></>) : (<><li><button onClick={openLogin} className='hover:text-green-200 transition'>Iniciar sesión</button></li><li><button onClick={openRegister} className='inline-flex items-center bg-white text-green-700 font-semibold px-4 py-2 rounded-xl shadow hover:bg-green-100 transition'>Registrarse</button></li></>)}</div>
+                        <li><Link href="/nosotros" className={`hover:text-green-200 transition ${pathname === '/nosotros' ? 'underline underline-offset-4' : ''}`}>{t('about')}</Link></li>
+                        <li><Link href='/ingresar' className='inline-flex items-center gap-2 bg-green-500 text-white font-semibold px-4 py-2 rounded-xl shadow hover:bg-green-600 transition whitespace-nowrap overflow-hidden text-ellipsis'><Leaf className='w-4 h-4' /> {t('recognizePlant')}</Link></li>
+                        {user && (<li><Link href='/crear-foro' className='inline-flex items-center gap-2 bg-white text-green-700 font-semibold px-4 py-2 rounded-xl shadow hover:bg-green-100 transition whitespace-nowrap'>{t('addForum')}</Link></li>)}
+                        <li>
+                            <LanguageToggle />
+                        </li>
+                        <div className='flex items-center space-x-4 ml-6 '>{user ? (<><li><span className='flex items-center'><UserCircle className='mr-2 h-5 w-5' /> {t('welcomeUser')} {user.nombre}</span></li><li><button onClick={handleLogout} className='inline-flex items-center gap-2 bg-red-500 text-white font-semibold px-4 py-2 rounded-xl shadow hover:bg-red-600 transition'><LogOut className='w-4 h-4' /> {t('logout')}</button></li></>) : (<><li><button onClick={openLogin} className='hover:text-green-200 transition'>{t('login')}</button></li><li><button onClick={openRegister} className='inline-flex items-center bg-white text-green-700 font-semibold px-4 py-2 rounded-xl shadow hover:bg-green-100 transition'>{t('register')}</button></li></>)}</div>
                     </ul>
                 </div>
 
@@ -167,14 +173,14 @@ export default function Navbar() {
                 {mobileOpen && (
     <div className='md:hidden bg-white text-green-700 shadow-lg z-10'>
         <ul className='flex flex-col space-y-2 px-4 pt-2 pb-4 text-base'>
-            {navItems.map(({ label, href }) => (
+            {navItems.map(({ key, href }) => (
                 <li key={href}>
                     <Link
                         href={href}
                         className={`block py-2 ${pathname === href ? 'font-semibold' : ''}`}
                         onClick={closeAllMobileMenus}
                     >
-                        {label}
+                        {t(key)}
                     </Link>
                 </li>
             ))}
@@ -185,7 +191,7 @@ export default function Navbar() {
                     onClick={() => setMobilePlantOpen(open => !open)}
                     className='w-full flex justify-between items-center py-2 font-medium'
                 >
-                    <span>Plantas</span>
+                    <span>{t('plants')}</span>
                     <svg className={`w-4 h-4 transition-transform ${mobilePlantOpen ? 'rotate-180' : ''}`} fill='none' stroke='currentColor' viewBox='0 0 24 24'>
                         <path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M19 9l-7 7-7-7' />
                     </svg>
@@ -194,7 +200,7 @@ export default function Navbar() {
                     <ul className='pl-4 mt-1 space-y-1 border-l border-green-200'>
                         <li>
                             <Link href='/plantas' className='block py-1 hover:bg-green-50' onClick={closeAllMobileMenus}>
-                                Todas
+                                {t('all')}
                             </Link>
                         </li>
                         {categorias.map(cat => (
@@ -209,7 +215,7 @@ export default function Navbar() {
             </li>
             <li>
                 <Link href='/nosotros' className={`block py-2 ${pathname === '/nosotros' ? 'font-semibold' : ''}`} onClick={closeAllMobileMenus}>
-                    Nosotros
+                    {t('about')}
                 </Link>
             </li>
 
@@ -221,19 +227,23 @@ export default function Navbar() {
                     onClick={closeAllMobileMenus}
                 >
                     <Leaf className='w-5 h-5' />
-                    <span>Reconocer planta</span>
+                    <span>{t('recognizePlant')}</span>
                 </Link>
             </li>
 
             {user && (
                 <li>
                     <Link href='/crear-foro' onClick={closeAllMobileMenus} className='block py-2 font-semibold'>
-                        Agregar foro
+                        {t('addForum')}
                     </Link>
                 </li>
             )}
 
             <hr className='my-2'/>
+
+            <li>
+                <LanguageToggle />
+            </li>
 
             {user ? (
                 <>
@@ -244,7 +254,7 @@ export default function Navbar() {
                     </li>
                     <li>
                         <button onClick={() => { handleLogout(); closeAllMobileMenus(); }} className='w-full text-left text-red-600 font-semibold py-2'>
-                            Cerrar Sesión
+                            {t('logout')}
                         </button>
                     </li>
                 </>
@@ -252,12 +262,12 @@ export default function Navbar() {
                 <>
                     <li>
                         <button onClick={() => { openLogin(); setMobileOpen(false); }} className='w-full text-left py-2'>
-                            Iniciar Sesión
+                            {t('login')}
                         </button>
                     </li>
                     <li>
                         <button onClick={() => { openRegister(); setMobileOpen(false); }} className='w-full text-left py-2'>
-                            Registrarse
+                            {t('register')}
                         </button>
                     </li>
                 </>


### PR DESCRIPTION
## Summary
- add LanguageProvider context with translations for English and Kichwa
- create LanguageToggle component for switching languages
- integrate language provider in layout and new toggle in navigation
- update navigation and home page text to use translations

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872ea69b5948328b254a3cb65645927